### PR TITLE
fix: serialization for Container and ArrayComposite

### DIFF
--- a/src/type/array_composite.zig
+++ b/src/type/array_composite.zig
@@ -71,12 +71,13 @@ pub fn withElementTypes(comptime ST: type, comptime ZT: type) type {
                 const out_slice = std.mem.bytesAsSlice(u32, out);
                 for (value, 0..) |*elem, i| {
                     // write offset
-                    // TODO: typescript always need offset here, confirm if Zig needs this or not thru unit test
+                    // Typescript needs offset but since Zig use slice, we don't need it
                     out_slice[i] = if (native_endian == .big) @byteSwap(variable_index) else variable_index;
 
                     // write serialized element to variable section
+                    // return number of bytes written
                     const elem_ptr = if (comptime @typeInfo(ZT) == .Pointer) elem.* else elem;
-                    variable_index = @intCast(try element_type.serializeToBytes(elem_ptr, out[variable_index..]));
+                    variable_index += @intCast(try element_type.serializeToBytes(elem_ptr, out[variable_index..]));
                 }
 
                 return variable_index;
@@ -244,7 +245,7 @@ pub fn withElementTypes(comptime ST: type, comptime ZT: type) type {
                     return error.offsetOutOfRange;
                 }
                 const prev_offset = offsets[i - 1];
-                if (off <= prev_offset) {
+                if (off < prev_offset) {
                     return error.offsetNotIncreasing;
                 }
                 offset.* = off;

--- a/src/type/container.zig
+++ b/src/type/container.zig
@@ -150,6 +150,7 @@ pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn)
             return size;
         }
 
+        /// Serialize the object to bytes, return the number of bytes written
         pub fn serializeToBytes(self: *const @This(), value: *const ZT, out: []u8) !usize {
             var fixed_index: usize = 0;
             var variable_index = self.fixed_end;
@@ -164,9 +165,11 @@ pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn)
                     const variable_index_endian = if (native_endian == .big) @byteSwap(variable_index) else variable_index;
                     slice[0] = @intCast(variable_index_endian);
                     fixed_index += 4;
-                    variable_index = try ssz_type.serializeToBytes(field_value_ptr, out[variable_index..]);
+                    // write serialized element to variable section
+                    // ssz_type.serializeToBytes returns number of bytes written
+                    variable_index += try ssz_type.serializeToBytes(field_value_ptr, out[variable_index..]);
                 } else {
-                    fixed_index = try ssz_type.serializeToBytes(field_value_ptr, out[fixed_index..]);
+                    fixed_index += try ssz_type.serializeToBytes(field_value_ptr, out[fixed_index..]);
                 }
             }
 

--- a/test/int/type/list_composite.zig
+++ b/test/int/type/list_composite.zig
@@ -93,11 +93,6 @@ test "ListCompositeType - element type Container" {
 }
 
 test "ListCompositeType - element type ListBasicType" {
-    // TODO: fix serialization bug
-    if (true) {
-        return error.SkipZigTest;
-    }
-
     const test_cases = [_]TestCase{
         TestCase{ .id = "empty", .serializedHex = "0x", .json = "[]", .rootHex = "0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5" },
         TestCase{ .id = "2 full values", .serializedHex = "0x080000000c0000000100020003000400", .json = 


### PR DESCRIPTION
**Description**
- for typescript, `serializeToBytes` returns absolute offset to the original DataView because there is no slice there and interface has to go with `DataView + offset`
- for zig, `serializeToBytes` is implemented in slice so it returns the number of bytes written, consumer need to accumulate it for correct offset
- also fix `readVariableOffsetsArrayComposite`, this is the same to typescript's implementation