### PR TITLE
feat: infer ZigType(ZT) from SSZType (ST)

### DIFF
--- a/src/type/bit_list.zig
+++ b/src/type/bit_list.zig
@@ -35,6 +35,15 @@ pub fn createBitListType(comptime limit_bits: usize) type {
         block_bytes: BlockBytes,
         mix_in_length_block_bytes: []u8,
 
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return BitArray;
+        }
+
+        pub fn getZigTypeAlignment() usize {
+            return @alignOf(BitArray);
+        }
+
         pub fn init(allocator: std.mem.Allocator, init_capacity: usize) !@This() {
             const limit_bytes = (limit_bits + 7) / 8;
             const max_chunk_count: usize = (limit_bytes + 31) / 32;

--- a/src/type/bit_vector.zig
+++ b/src/type/bit_vector.zig
@@ -39,6 +39,15 @@ pub const BitVectorType = struct {
     // this should always be a multiple of 64 bytes
     block_bytes: []u8,
 
+    /// Zig Type definition
+    pub fn getZigType() type {
+        return BitArray;
+    }
+
+    pub fn getZigTypeAlignment() usize {
+        return @alignOf(BitArray);
+    }
+
     pub fn init(allocator: std.mem.Allocator, comptime length_bits: usize) !@This() {
         if (length_bits <= 0) {
             return error.InvalidLength;

--- a/src/type/boolean.zig
+++ b/src/type/boolean.zig
@@ -15,6 +15,15 @@ pub const BooleanType = struct {
     min_size: usize,
     max_size: usize,
 
+    /// Zig type definition
+    pub fn getZigType() type {
+        return bool;
+    }
+
+    pub fn getZigTypeAlignment() usize {
+        return 1;
+    }
+
     pub fn init() @This() {
         return @This(){ .fixed_size = 1, .byte_len = 1, .items_per_chunk = 32, .min_size = 1, .max_size = 1 };
     }

--- a/src/type/byte_list.zig
+++ b/src/type/byte_list.zig
@@ -34,6 +34,15 @@ pub fn createByteListType(comptime limit_bytes: usize) type {
         block_bytes: BlockBytes,
         mix_in_length_block_bytes: []u8,
 
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return []u8;
+        }
+
+        pub fn getZigTypeAlignment() usize {
+            return @alignOf([]u8);
+        }
+
         pub fn init(allocator: std.mem.Allocator, init_capacity: usize) !@This() {
             return @This(){ .allocator = allocator, .block_bytes = try BlockBytes.initCapacity(allocator, init_capacity), .mix_in_length_block_bytes = try allocator.alloc(u8, 64) };
         }

--- a/src/type/byte_vector_type.zig
+++ b/src/type/byte_vector_type.zig
@@ -25,6 +25,15 @@ pub const ByteVectorType = struct {
     // this should always be a multiple of 64 bytes
     block_bytes: []u8,
 
+    /// Zig Type definition
+    pub fn getZigType() type {
+        return []u8;
+    }
+
+    pub fn getZigTypeAlignment() usize {
+        return @alignOf([]u8);
+    }
+
     pub fn init(allocator: std.mem.Allocator, length_bytes: usize) !@This() {
         const max_chunk_count: usize = (length_bytes + 31) / 32;
         const chunk_depth = maxChunksToDepth(max_chunk_count);

--- a/src/type/container.zig
+++ b/src/type/container.zig
@@ -43,6 +43,8 @@ pub fn createContainerType(comptime ST: type, hashFn: HashFn) type {
         };
     }
 
+    // this works for Zig 0.13
+    // syntax in 0.14 or later could change, see https://github.com/ziglang/zig/issues/10710
     const ZT = comptime @Type(.{
         .Struct = .{
             .layout = .auto,

--- a/src/type/container.zig
+++ b/src/type/container.zig
@@ -21,7 +21,39 @@ const BytesRange = struct {
 /// TODO: defaultValue() for all types
 // create a ssz type from type of an ssz object
 // type of zig type will be used once and checked inside hashTreeRoot() function
-pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn) type {
+pub fn createContainerType(comptime ST: type, hashFn: HashFn) type {
+    const ssz_struct_info = switch (@typeInfo(ST)) {
+        .Struct => |struct_info| struct_info,
+        else => @compileError("Expected a struct type."),
+    };
+
+    comptime var new_fields: [ssz_struct_info.fields.len]std.builtin.Type.StructField = undefined;
+    comptime var alignment: usize = 0;
+    inline for (ssz_struct_info.fields, 0..) |field, i| {
+        if (field.type.getZigTypeAlignment() > alignment) {
+            alignment = field.type.getZigTypeAlignment();
+        }
+        new_fields[i] = .{
+            .name = field.name,
+            .type = field.type.getZigType(),
+            // TODO: implement this
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = field.type.getZigTypeAlignment(),
+        };
+    }
+
+    const ZT = comptime @Type(.{
+        .Struct = .{
+            .layout = .auto,
+            .backing_integer = null,
+            .fields = new_fields[0..],
+            // TODO: do we need to assign this value?
+            .decls = &[_]std.builtin.Type.Declaration{},
+            .is_tuple = false,
+        },
+    });
+
     const zig_fields_info = @typeInfo(ZT).Struct.fields;
     const max_chunk_count = zig_fields_info.len;
     const native_endian = @import("builtin").target.cpu.arch.endian();
@@ -39,6 +71,17 @@ pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn)
         fixed_size: ?usize,
         fixed_end: usize,
         variable_field_count: usize,
+
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return ZT;
+        }
+
+        /// to be used by parent
+        /// an alignment of struct is max of all fields' alignment
+        pub fn getZigTypeAlignment() usize {
+            return alignment;
+        }
 
         /// public function for consumers
         /// TODO: consider returning *@This(), see BitArray
@@ -340,6 +383,7 @@ pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn)
 }
 
 test "basic ContainerType {x: uint, y:bool}" {
+    std.debug.print("basic ContainerType x: uint, y:bool\n", .{});
     var allocator = std.testing.allocator;
     const UintType = @import("./uint.zig").createUintType(8);
     const uintType = try UintType.init();
@@ -351,11 +395,8 @@ test "basic ContainerType {x: uint, y:bool}" {
         x: UintType,
         y: BooleanType,
     };
-    const ZigType = struct {
-        x: u64,
-        y: bool,
-    };
-    const ContainerType = createContainerType(SszType, ZigType, sha256Hash);
+    const ContainerType = createContainerType(SszType, sha256Hash);
+    const ZigType = ContainerType.getZigType();
     var containerType = try ContainerType.init(allocator, SszType{
         .x = uintType,
         .y = booleanType,
@@ -404,11 +445,8 @@ test "ContainerType with embedded struct" {
         x: UintType,
         y: UintType,
     };
-    const ZigType0 = struct {
-        x: u64,
-        y: u64,
-    };
-    const ContainerType0 = createContainerType(SszType0, ZigType0, sha256Hash);
+    const ContainerType0 = createContainerType(SszType0, sha256Hash);
+    const ZigType0 = ContainerType0.getZigType();
     const containerType0 = try ContainerType0.init(allocator, SszType0{
         .x = uintType,
         .y = uintType,
@@ -419,11 +457,8 @@ test "ContainerType with embedded struct" {
         a: ContainerType0,
         b: ContainerType0,
     };
-    const ZigType1 = struct {
-        a: ZigType0,
-        b: ZigType0,
-    };
-    const ContainerType1 = createContainerType(SszType1, ZigType1, sha256Hash);
+    const ContainerType1 = createContainerType(SszType1, sha256Hash);
+    const ZigType1 = ContainerType1.getZigType();
     var containerType1 = try ContainerType1.init(allocator, SszType1{
         .a = containerType0,
         .b = containerType0,

--- a/src/type/list_basic.zig
+++ b/src/type/list_basic.zig
@@ -19,8 +19,9 @@ const Parsed = @import("./type.zig").Parsed;
 /// List: ordered variable-length homogeneous collection, limited to N values
 /// ST: ssz element type
 /// ZT: zig element type
-pub fn createListBasicType(comptime ST: type, comptime ZT: type) type {
+pub fn createListBasicType(comptime ST: type) type {
     const BlockBytes = ArrayList(u8);
+    const ZT = ST.getZigType();
     const ArrayBasic = @import("./array_basic.zig").withElementTypes(ST, ZT);
     const ParsedResult = Parsed([]ZT);
 
@@ -37,6 +38,15 @@ pub fn createListBasicType(comptime ST: type, comptime ZT: type) type {
         // this should always be a multiple of 64 bytes
         block_bytes: BlockBytes,
         mix_in_length_block_bytes: []u8,
+
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return []ZT;
+        }
+
+        pub fn getZigTypeAlignment() usize {
+            return @alignOf([]ZT);
+        }
 
         /// init_capacity is the initial capacity of elements, not bytes
         pub fn init(allocator: std.mem.Allocator, element_type: *ST, limit: usize, init_capacity: usize) !@This() {
@@ -146,7 +156,7 @@ test "deserializeFromBytes" {
 
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
-    const ListBasicType = createListBasicType(UintType, u64);
+    const ListBasicType = createListBasicType(UintType);
     var uintType = try UintType.init();
     var listType = try ListBasicType.init(allocator, &uintType, 128, 128);
     defer uintType.deinit();
@@ -204,7 +214,7 @@ test "deserializeFromJson" {
 
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
-    const ListBasicType = createListBasicType(UintType, u64);
+    const ListBasicType = createListBasicType(UintType);
     var uintType = try UintType.init();
     var listType = try ListBasicType.init(allocator, &uintType, 4, 2);
     defer uintType.deinit();

--- a/src/type/uint.zig
+++ b/src/type/uint.zig
@@ -30,6 +30,15 @@ pub fn createUintType(comptime num_bytes: usize) type {
         min_size: usize,
         max_size: usize,
 
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return T;
+        }
+
+        pub fn getZigTypeAlignment() usize {
+            return num_bytes;
+        }
+
         pub fn init() !@This() {
             return @This(){ .fixed_size = num_bytes, .byte_length = num_bytes, .min_size = 0, .max_size = num_bytes };
         }

--- a/src/type/vector_basic.zig
+++ b/src/type/vector_basic.zig
@@ -16,7 +16,8 @@ const Parsed = @import("./type.zig").Parsed;
 /// Vector: Ordered fixed-length homogeneous collection, with N values
 /// ST: ssz element type
 /// ZT: zig element type
-pub fn createVectorBasicType(comptime ST: type, comptime ZT: type) type {
+pub fn createVectorBasicType(comptime ST: type) type {
+    const ZT = ST.getZigType();
     const ArrayBasic = @import("./array_basic.zig").withElementTypes(ST, ZT);
     const ParsedResult = Parsed([]ZT);
 
@@ -32,6 +33,15 @@ pub fn createVectorBasicType(comptime ST: type, comptime ZT: type) type {
         max_size: usize,
         // this should always be a multiple of 64 bytes
         block_bytes: []u8,
+
+        /// Zig Type definition
+        pub fn getZigType() type {
+            return []ZT;
+        }
+
+        pub fn getZigTypeAlignment() usize {
+            return @alignOf([]ZT);
+        }
 
         pub fn init(allocator: std.mem.Allocator, element_type: *ST, length: usize) !@This() {
             const elem_byte_length = element_type.byte_length;
@@ -145,7 +155,7 @@ test "deserializeFromBytes" {
 
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
-    const VectorBasicType = createVectorBasicType(UintType, u64);
+    const VectorBasicType = createVectorBasicType(UintType);
     var uintType = try UintType.init();
     var vectorType = try VectorBasicType.init(allocator, &uintType, 8);
     defer uintType.deinit();
@@ -199,7 +209,7 @@ test "deserializeFromJson" {
 
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
-    const VectorBasicType = createVectorBasicType(UintType, u64);
+    const VectorBasicType = createVectorBasicType(UintType);
     var uintType = try UintType.init();
     var vectorType = try VectorBasicType.init(allocator, &uintType, 4);
     defer uintType.deinit();

--- a/test/int/type/byte_list.zig
+++ b/test/int/type/byte_list.zig
@@ -82,7 +82,7 @@ test "ListBasicType[u8, 256]" {
 
     // uint of 1 bytes = u8
     const UintType = createUintType(1);
-    const ListBasicType = createListBasicType(UintType, u8);
+    const ListBasicType = createListBasicType(UintType);
     var uintType = try UintType.init();
     var list_type = try ListBasicType.init(allocator, &uintType, 256, 256);
     defer uintType.deinit();

--- a/test/int/type/container.zig
+++ b/test/int/type/container.zig
@@ -15,12 +15,8 @@ test "ContainerType with 2 uints" {
         a: UintType,
         b: UintType,
     };
-    const ZigType = struct {
-        a: u64,
-        b: u64,
-    };
 
-    const ContainerType = createContainerType(SszType, ZigType, sha256Hash);
+    const ContainerType = createContainerType(SszType, sha256Hash);
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
@@ -63,7 +59,7 @@ test "ContainerType with ListBasicType(uint64, 128) and uint64" {
     var uintType = try UintType.init();
     defer uintType.deinit();
 
-    const ListBasicType = createListBasicType(UintType, u64);
+    const ListBasicType = createListBasicType(UintType);
     var listBasicType = try ListBasicType.init(allocator, &uintType, 128, 128);
     defer listBasicType.deinit();
 
@@ -71,12 +67,8 @@ test "ContainerType with ListBasicType(uint64, 128) and uint64" {
         a: ListBasicType,
         b: UintType,
     };
-    const ZigType = struct {
-        a: []u64,
-        b: u64,
-    };
 
-    const ContainerType = createContainerType(SszType, ZigType, sha256Hash);
+    const ContainerType = createContainerType(SszType, sha256Hash);
     var containerType = try ContainerType.init(allocator, SszType{
         .a = listBasicType,
         .b = uintType,

--- a/test/int/type/list_basic.zig
+++ b/test/int/type/list_basic.zig
@@ -30,7 +30,7 @@ test "valid test for ListBasicType" {
     // uint of 8 bytes = u64
     const UintType = createUintType(8);
     // TODO
-    const ListBasicType = createListBasicType(UintType, u64);
+    const ListBasicType = createListBasicType(UintType);
     var uintType = try UintType.init();
     var listType = try ListBasicType.init(allocator, &uintType, 128, 128);
     defer uintType.deinit();

--- a/test/int/type/list_composite.zig
+++ b/test/int/type/list_composite.zig
@@ -31,7 +31,7 @@ test "ListCompositeType - element type ByteVectorType" {
     var byte_vector_type = try ByteVectorType.init(allocator, 32);
     defer byte_vector_type.deinit();
 
-    const ListCompositeType = createListCompositeType(ByteVectorType, []u8);
+    const ListCompositeType = createListCompositeType(ByteVectorType);
     var list = try ListCompositeType.init(allocator, &byte_vector_type, 128, 4);
     defer list.deinit();
 
@@ -68,19 +68,15 @@ test "ListCompositeType - element type Container" {
         a: UintType,
         b: UintType,
     };
-    const ZigType = struct {
-        a: u64,
-        b: u64,
-    };
 
-    const ContainerType = createContainerType(SszType, ZigType, sha256Hash);
+    const ContainerType = createContainerType(SszType, sha256Hash);
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
     });
     defer containerType.deinit();
 
-    const ListCompositeType = createListCompositeType(ContainerType, ZigType);
+    const ListCompositeType = createListCompositeType(ContainerType);
     var list = try ListCompositeType.init(allocator, &containerType, 128, 4);
     defer list.deinit();
 
@@ -114,11 +110,11 @@ test "ListCompositeType - element type ListBasicType" {
     var u16Type = try UintType.init();
     defer u16Type.deinit();
 
-    const ListBasicType = createListBasicType(UintType, u16);
+    const ListBasicType = createListBasicType(UintType);
     var listBasicType = try ListBasicType.init(allocator, &u16Type, 2, 2);
     defer listBasicType.deinit();
 
-    const ListCompositeType = createListCompositeType(ListBasicType, []u16);
+    const ListCompositeType = createListCompositeType(ListBasicType);
     var listCompositeType = try ListCompositeType.init(allocator, &listBasicType, 2, 2);
     defer listCompositeType.deinit();
 

--- a/test/int/type/vector_basic.zig
+++ b/test/int/type/vector_basic.zig
@@ -25,7 +25,7 @@ test "valid test for VectorBasicType" {
 
     // uint of 8 bytes = u64
     const UintType = createUintType(8);
-    const VectorBasicType = createVectorBasicType(UintType, u64);
+    const VectorBasicType = createVectorBasicType(UintType);
     var uintType = try UintType.init();
     var vectorType = try VectorBasicType.init(allocator, &uintType, 8);
     defer uintType.deinit();

--- a/test/int/type/vector_composite.zig
+++ b/test/int/type/vector_composite.zig
@@ -26,7 +26,7 @@ test "VectorCompositeType of Root" {
     var byte_vector_type = try ByteVectorType.init(allocator, 32);
     defer byte_vector_type.deinit();
 
-    const VectorCompositeType = createVectorCompositeType(ByteVectorType, []u8);
+    const VectorCompositeType = createVectorCompositeType(ByteVectorType);
     var vector_composite_type = try VectorCompositeType.init(allocator, &byte_vector_type, 4);
     defer vector_composite_type.deinit();
 
@@ -59,19 +59,15 @@ test "VectorCompositeType of Container" {
         a: UintType,
         b: UintType,
     };
-    const ZigType = struct {
-        a: u64,
-        b: u64,
-    };
 
-    const ContainerType = createContainerType(SszType, ZigType, sha256Hash);
+    const ContainerType = createContainerType(SszType, sha256Hash);
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
     });
     defer containerType.deinit();
 
-    const VectorCompositeType = createVectorCompositeType(ContainerType, ZigType);
+    const VectorCompositeType = createVectorCompositeType(ContainerType);
     var vector_composite_type = try VectorCompositeType.init(allocator, &containerType, 4);
     defer vector_composite_type.deinit();
 


### PR DESCRIPTION
**Motivation**
- for typescript, to define a SSZ type it's pretty simple

```typescript
export const ValidatorType = {
  pubkey: BLSPubkey,
  withdrawalCredentials: Bytes32,
  effectiveBalance: UintNum64,
  slashed: Boolean,
  activationEligibilityEpoch: EpochInf,
  activationEpoch: EpochInf,
  exitEpoch: EpochInf,
  withdrawableEpoch: EpochInf,
};
```
based on that it uses `ValueOf` utility to infer Typescript type

- however for now in zig it has to define both ssz type and zig type
```zig
pub fn createContainerType(comptime ST: type, comptime ZT: type, hashFn: HashFn) type {
```

should be able to infer `ZT` from `ST` similar to typescript

**Description**
- infer zig type `ZT` from `ST`
  - each type needs to define `getZigType() type` and `getZigTypeAlignment() usize` at struct level
  - at compile time, infer zig type for parent type from child type using the 2 methods above
  - the creation of zig type becomes simpler since we drop `ZT`, it is now the same to typescript's with 1 extra param for `hashFn`
```zig
pub fn createContainerType(comptime ST: type, hashFn: HashFn) type {
```

  - to get zig type from a SSZ type, use `SSZType.getZigType()`, this is struct method. This is equivalent to `ValueOf()` in Typescript ssz
  - the implementation is mainly in ContainerType, syntax could be changed in future version of Zig https://github.com/ziglang/zig/issues/10710
```zig
comptime var new_fields: [ssz_struct_info.fields.len]std.builtin.Type.StructField = undefined;
    comptime var alignment: usize = 0;
    inline for (ssz_struct_info.fields, 0..) |field, i| {
        if (field.type.getZigTypeAlignment() > alignment) {
            alignment = field.type.getZigTypeAlignment();
        }
        new_fields[i] = .{
            .name = field.name,
            .type = field.type.getZigType(),
            // TODO: implement this
            .default_value = null,
            .is_comptime = false,
            .alignment = field.type.getZigTypeAlignment(),
        };
    }

    const ZT = comptime @Type(.{
        .Struct = .{
            .layout = .auto,
            .backing_integer = null,
            .fields = new_fields[0..],
            // TODO: do we need to assign this value?
            .decls = &[_]std.builtin.Type.Declaration{},
            .is_tuple = false,
        },
    });
```