### PR TITLE
feat: persistent merkle tree initial implementation

### DIFF
--- a/packages/common/src/hex.zig
+++ b/packages/common/src/hex.zig
@@ -28,6 +28,19 @@ pub fn toRootHex(root: []const u8) ![]u8 {
     return buffer[0..];
 }
 
+pub fn rootIntoHex(out: []u8, root: []const u8) !void {
+    if (root.len != 32) {
+        return error.InvalidInput;
+    }
+
+    if (out.len != 66) {
+        return error.InvalidOutputLength;
+    }
+
+    const hex = try toRootHex(root);
+    @memcpy(out, hex);
+}
+
 pub fn fromHex(hex: []const u8, out: []u8) !void {
     if (hex.len == 0) {
         return;

--- a/packages/common/src/root.zig
+++ b/packages/common/src/root.zig
@@ -1,3 +1,4 @@
 pub const toRootHex = @import("hex.zig").toRootHex;
 pub const fromHex = @import("hex.zig").fromHex;
+pub const rootIntoHex = @import("hex.zig").rootIntoHex;
 pub const FromHexError = @import("hex.zig").FromHexError;

--- a/packages/persistent-merkle-tree/README.md
+++ b/packages/persistent-merkle-tree/README.md
@@ -1,0 +1,143 @@
+# Persistent Merkle Tree
+
+![Zig 0.13](https://img.shields.io/badge/Zig-F7A41D?logo=zig&logoColor=fff)
+
+A binary merkle tree implemented as a [persistent data structure](https://en.wikipedia.org/wiki/Persistent_data_structure).
+This is a port of [typescript implementation](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-merkle-tree).
+
+## Example
+
+```zig
+// LeafNode and BranchNode are used to build nodes in a tree
+// Nodes may not be changed once initialized
+
+const allocator = std.testing.allocator;
+var pool = try NodePool.init(allocator, 10);
+defer pool.deinit();
+
+const hash1: [32]u8 = [_]u8{1} ** 32;
+const hash2: [32]u8 = [_]u8{2} ** 32;
+const leaf = try pool.newLeaf(&hash1);
+const otherLeaf = try pool.newLeaf(&hash2);
+
+var branch = try pool.newBranch(leaf1, leaf2);
+
+// The `root` property returns the merkle root of a Node
+
+// this is equal to `hash(leaf.root, otherLeaf.root));`
+const root = nm.getRoot(branch);
+
+// cleanup
+try pool.unref(branch);
+
+// Well-known zero nodes are provided
+
+// 0x0
+const zero0 = try pool.getZeroNode(0);
+
+// hash(0, 0)
+const zero1 = try pool.getZeroNode(0);
+
+// hash(hash(0, 0), hash(0, 0))
+const zero2 = try pool.getZeroNode(0);
+
+// Tree provides a mutable wrapper around a "root" Node
+
+const tree = pool.getTree(try pool.getZeroNode(10));
+
+// `rootNode` property returns the root Node of a Tree
+
+const rootNode = tree.getRootNode();
+
+// `root` property returns the merkle root of a Tree
+
+const rr = try tree.getRoot();
+
+// A Tree is navigated by Gindex
+
+const gindex: u64 = ...;
+
+const n: Node = try tree.getTreeNode(gindex); // the Node at gindex
+const rrr: Uint8Array = try tree.getRootOfNode(gindex); // the *[32]u8 root at gindex
+const subtree: Tree = tree.getSubtree(gindex); // the Tree wrapping the Node at gindex. Updates to `subtree` will be propagated to `tree`
+
+```
+
+## Motivation
+
+When dealing with large datasets, it is very expensive to merkleize them in their entirety. In cases where large datasets are remerkleized often between updates and additions, using ephemeral structures for intermediate hashes results in significant duplicated work, as many intermediate hashes will be recomputed and thrown away on each merkleization. In these cases, maintaining structures for the entire tree, intermediate nodes included, can mitigate these issues and allow for additional usecases (eg: proof generation). This implementation also uses the known immutability of nodes to share data between common subtrees across different versions of the data.
+
+## Features
+
+#### Intermediate nodes with cached, lazily computed hashes
+
+The tree is represented as a linked tree of `Node`s, currently either `BranchNode`s or `LeafNode`s or `ZeroNode`s.
+A `BranchNode` has a `left` and `right` child `Node`, and a `root`, 32 byte `*[32]u8`.
+A `LeafNode` has a `root`.
+The `root` of a `Node` is not computed until requested, and cached thereafter.
+
+#### Shared data betwen common subtrees
+
+Any update to a tree (either to a leaf or intermediate node) is performed as a rebinding that yields a new, updated tree that maximally shares data between versions. Garbage collection allows memory from unused nodes to be eventually reclaimed.
+
+#### Mutable wrapper for the persistent core
+
+A `Tree` object wraps `Node` and provides an API for tree navigation and transparent rebinding on updates.
+
+#### Navigation by gindex or (depth, index)
+
+Many tree methods allow navigation with a gindex. A gindex (or generalized index) describes a path through the tree, starting from the root and nagivating downwards.
+
+```
+     1
+   /   \
+  2     3
+/  \   /  \
+4  5   6  7
+```
+
+It can also be interpreted as a bitstring, starting with "1", then appending "0" for each navigation left, or "1" for each navigation right.
+
+```
+        1
+    /      \
+   10       11
+ /    \    /    \
+100  101  110  111
+```
+
+Alternatively, several tree methods, with names ending with `AtDepth`, allow navigation by (depth, index). Depth and index navigation works by first navigating down levels into the tree from the top, starting at 0 (depth), and indexing nodes from the left, starting at 0 (index).
+
+```
+     0          <- depth 0
+   /   \
+  0     1       <- depth 1
+/  \   /  \
+0  1   2  3     <- depth 2
+```
+
+#### Memory efficiency
+
+The Merkle tree implementation uses a centralized node pool to manage all nodes efficiently. Nodes are created by the pool and reused to minimize memory allocations. When a node is no longer needed, you should call the `unref()` method, which decreases the node's reference count.
+
+- Reference Counting: Each node tracks its usage with a reference count. When the count reaches zero, the node is returned to the pool.
+- Reusability: Returned nodes are stored in the pool's LeafList and BranchList, making them available for reuse. This significantly reduces the need for frequent memory allocation during the application's lifetime.
+- Memory Allocation: A single allocator is managed within the pool, simplifying memory management across the API. When trees are no longer in use, nodes should be returned to the pool via the `unref()` method. The pool will then handle cleanup and deallocate memory when required.
+
+This design ensures efficient memory usage and optimal performance, especially in applications where nodes are frequently created and discarded.
+
+#### Navigation efficiency
+
+In performance-critical applications performing many reads and writes to trees, being smart with tree navigation is crucial. This library correctly provides tree navigation methods that handle several important optimized cases: multi-node get and set, and get-then-set operations.
+
+## See also:
+
+https://github.com/protolambda/remerkleable
+
+### Audit
+
+This repo was audited by Least Authority as part of [this security audit](https://github.com/ChainSafe/lodestar/blob/master/audits/2020-03-23_UTILITY_LIBRARIES.pdf), released 2020-03-23. Commit [`8b5ad7`](https://github.com/ChainSafe/bls-hd-key/commit/8b5ad7) verified in the report.
+
+## License
+
+Apache-2.0

--- a/packages/persistent-merkle-tree/src/const.zig
+++ b/packages/persistent-merkle-tree/src/const.zig
@@ -1,0 +1,3 @@
+/// this helps avoid heap memory allocation in setNodesAtDepth() below
+/// VALIDATOR_REGISTRY_LIMIT is only 2**40 (= 1,099,511,627,776)
+pub const MAX_NODES_DEPTH = 64;

--- a/packages/persistent-merkle-tree/src/node.zig
+++ b/packages/persistent-merkle-tree/src/node.zig
@@ -1,0 +1,127 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const digest64Into = @import("./sha256.zig").digest64Into;
+
+pub const NodeType = enum {
+    Branch,
+    Leaf,
+};
+
+pub const Node = union(NodeType) {
+    Branch: BranchNode,
+    Leaf: LeafNode,
+};
+
+pub const BranchNode = struct {
+    hash: *[32]u8,
+    hash_computed: bool,
+    left: *Node,
+    right: *Node,
+    ref_count: usize,
+
+    pub fn init(allocator: Allocator, left: *Node, right: *Node) !*BranchNode {
+        const branch = try allocator.create(BranchNode);
+        branch.hash = try allocator.create([32]u8);
+        branch.left = left;
+        branch.right = right;
+        branch.hash_computed = false;
+        branch.ref_count = 0;
+        incRefCount(left);
+        incRefCount(right);
+        return branch;
+    }
+
+    pub fn root(self: *BranchNode) *[32]u8 {
+        if (self.hash_computed == true) {
+            return self.hash;
+        }
+        // TODO: change digest64Into() to accept *[32]u8
+        digest64Into(getRoot(self.left).*[0..], getRoot(self.right).*[0..], self.hash);
+        self.hash_computed = true;
+        return self.hash;
+    }
+
+    pub fn decRefCount(node: *BranchNode) void {
+        // TODO: extract to a util?
+        if (node.ref_count > 0) {
+            node.ref_count -= 1;
+            return;
+        }
+        node.ref_count = 0;
+    }
+};
+
+pub const LeafNode = struct {
+    hash: *[32]u8,
+    ref_count: usize,
+
+    pub fn init(allocator: Allocator, hash: *const [32]u8) !*LeafNode {
+        const leaf = try allocator.create(LeafNode);
+        leaf.hash = try allocator.create([32]u8);
+        @memcpy(leaf.hash.*[0..], hash.*[0..]);
+        leaf.ref_count = 0;
+        return leaf;
+    }
+
+    pub fn root(self: *LeafNode) *[32]u8 {
+        return self.hash;
+    }
+
+    pub fn decRefCount(node: *LeafNode) void {
+        // TODO: extract to a util?
+        if (node.ref_count > 0) {
+            node.ref_count -= 1;
+            return;
+        }
+        node.ref_count = 0;
+    }
+};
+
+pub fn initBranchNode(allocator: Allocator, left: *Node, right: *Node) !*Node {
+    const branch = try BranchNode.init(allocator, left, right);
+    const node = try allocator.create(Node);
+    node.* = Node{ .Branch = branch.* };
+    return node;
+}
+
+pub fn initLeafNode(allocator: Allocator, hash: *const [32]u8) !*Node {
+    const leaf = try LeafNode.init(allocator, hash);
+    const node = try allocator.create(Node);
+    node.* = Node{ .Leaf = leaf.* };
+    return node;
+}
+
+pub fn getRoot(node: *Node) *[32]u8 {
+    switch (node.*) {
+        .Leaf => return node.Leaf.root(),
+        .Branch => return node.Branch.root(),
+    }
+}
+
+pub fn incRefCount(node: *Node) void {
+    switch (node.*) {
+        .Leaf => node.Leaf.ref_count += 1,
+        .Branch => node.Branch.ref_count += 1,
+    }
+}
+
+pub fn decRefCount(node: *Node) void {
+    switch (node.*) {
+        .Leaf => node.Leaf.ref_count = @max(node.Leaf.ref_count - 1, 0),
+        .Branch => node.Branch.ref_count = @max(node.Branch.ref_count - 1, 0),
+    }
+}
+
+pub fn setRefCount(node: *Node, count: usize) void {
+    switch (node.*) {
+        .Leaf => node.Leaf.ref_count = count,
+        .Branch => node.Branch.ref_count = count,
+    }
+}
+
+pub fn getRefCount(node: *Node) usize {
+    switch (node.*) {
+        .Leaf => return node.Leaf.ref_count,
+        .Branch => return node.Branch.ref_count,
+    }
+}

--- a/packages/persistent-merkle-tree/src/node.zig
+++ b/packages/persistent-merkle-tree/src/node.zig
@@ -133,6 +133,20 @@ pub fn getRoot(node: *Node) *const [32]u8 {
     }
 }
 
+pub fn getLeft(node: *Node) !*Node {
+    switch (node.*) {
+        .Branch => return node.Branch.left,
+        else => return error.NoLeft,
+    }
+}
+
+pub fn getRight(node: *Node) !*Node {
+    switch (node.*) {
+        .Branch => return node.Branch.right,
+        else => return error.NoRight,
+    }
+}
+
 pub fn incRefCount(node: *Node) void {
     switch (node.*) {
         .Leaf => node.Leaf.ref_count += 1,

--- a/packages/persistent-merkle-tree/src/node.zig
+++ b/packages/persistent-merkle-tree/src/node.zig
@@ -90,16 +90,16 @@ pub const LeafNode = struct {
 /// if level 0, it's a leaf node without ref count
 /// from level 1, it's the BranchNode with no ref count
 pub const ZeroNode = struct {
-    hash: *const [32]u8,
+    hash: *[32]u8,
     // these are ZeroNode but want to conform to get* function signature
     left: ?*Node,
     right: ?*Node,
 
     // called and managed by NodePool
-    pub fn init(allocator: Allocator, hash: *const [32]u8, left: ?*Node, right: ?*Node) !*ZeroNode {
+    pub fn init(allocator: Allocator, zero_hash: *const [32]u8, left: ?*Node, right: ?*Node) !*ZeroNode {
         const zero = try allocator.create(ZeroNode);
-        // no need to copy because the input hash is zero_hash which is allocated by the same allocator
-        zero.hash = hash;
+        zero.hash = try allocator.create([32]u8);
+        @memcpy(zero.hash.*[0..], zero_hash.*[0..]);
         zero.left = left;
         zero.right = right;
         return zero;

--- a/packages/persistent-merkle-tree/src/node.zig
+++ b/packages/persistent-merkle-tree/src/node.zig
@@ -151,7 +151,7 @@ pub fn getRoot(node: *Node) *const [32]u8 {
     }
 }
 
-pub fn getLeft(node: *Node) !*Node {
+pub fn getLeft(node: *const Node) !*Node {
     switch (node.*) {
         .Branch => return node.Branch.left,
         .Zero => return node.Zero.left orelse return error.NoLeft,
@@ -159,7 +159,7 @@ pub fn getLeft(node: *Node) !*Node {
     }
 }
 
-pub fn getRight(node: *Node) !*Node {
+pub fn getRight(node: *const Node) !*Node {
     switch (node.*) {
         .Branch => return node.Branch.right,
         .Zero => return node.Zero.right orelse return error.NoRight,

--- a/packages/persistent-merkle-tree/src/pool.zig
+++ b/packages/persistent-merkle-tree/src/pool.zig
@@ -28,6 +28,8 @@ pub const NodePool = struct {
         const place_holder = try nm.initLeafNode(allocator, &[_]u8{0} ** 32);
         const zero_list = try allocator.alloc(*Node, MAX_NODES_DEPTH);
         try zh.initZeroHash(&allocator, MAX_NODES_DEPTH);
+        // TODO: somehow put this in deinit() causes segmentation fault
+        defer zh.deinitZeroHash();
         for (0..MAX_NODES_DEPTH) |i| {
             const prev_zero = if (i == 0) null else zero_list[i - 1];
             zero_list[i] = try nm.initZeroNode(allocator, try zh.getZeroHash(i), prev_zero, prev_zero);
@@ -61,9 +63,6 @@ pub const NodePool = struct {
         self.allocator.free(self.zero_list);
 
         nm.destroyNode(self.allocator, self.place_holder);
-
-        // TODO: segmentation fault or zero_hash leaked
-        // zh.deinitZeroHash();
     }
 
     pub fn newLeaf(self: *NodePool, hash: *const [32]u8) !*Node {

--- a/packages/persistent-merkle-tree/src/pool.zig
+++ b/packages/persistent-merkle-tree/src/pool.zig
@@ -67,7 +67,7 @@ pub const NodePool = struct {
     }
 
     pub fn getTree(self: *NodePool, root: *Node) Tree {
-        return Tree{ .root_node = root, .pool = self };
+        return Tree{ ._root_node = root, .pool = self, .parent = null };
     }
 
     pub fn newLeaf(self: *NodePool, hash: *const [32]u8) !*Node {
@@ -91,7 +91,7 @@ pub const NodePool = struct {
     }
 
     /// cannot make left and right as const since we may modify its ref_count
-    pub fn newBranch(self: *NodePool, left: *Node, right: *Node) !*Node {
+    pub fn newBranch(self: *NodePool, left: *Node, right: *Node) nm.NodeError!*Node {
         const nodeOrNull = self.branch_nodes.popOrNull();
         if (nodeOrNull) |node| {
             // reuse BranchNode from pool
@@ -123,7 +123,7 @@ pub const NodePool = struct {
         return self.zero_list[depth];
     }
 
-    pub fn unref(self: *NodePool, node: *Node) !void {
+    pub fn unref(self: *NodePool, node: *Node) Allocator.Error!void {
         switch (node.*) {
             .Leaf => {
                 const leaf = &node.Leaf;

--- a/packages/persistent-merkle-tree/src/pool.zig
+++ b/packages/persistent-merkle-tree/src/pool.zig
@@ -74,6 +74,7 @@ pub const NodePool = struct {
         return node;
     }
 
+    /// cannot make left and right as const since we may modify its ref_count
     pub fn newBranch(self: *NodePool, left: *Node, right: *Node) !*Node {
         const nodeOrNull = self.branch_nodes.popOrNull();
         if (nodeOrNull) |node| {

--- a/packages/persistent-merkle-tree/src/pool.zig
+++ b/packages/persistent-merkle-tree/src/pool.zig
@@ -10,6 +10,7 @@ const BranchNode = nm.BranchNode;
 const LeafNode = nm.LeafNode;
 const MAX_NODES_DEPTH = @import("./const.zig").MAX_NODES_DEPTH;
 const zh = @import("./zero_hash.zig");
+const Tree = @import("./tree.zig").Tree;
 
 const LeafList = ArrayList(*Node);
 const BranchList = ArrayList(*Node);
@@ -63,6 +64,10 @@ pub const NodePool = struct {
         self.allocator.free(self.zero_list);
 
         nm.destroyNode(self.allocator, self.place_holder);
+    }
+
+    pub fn getTree(self: *NodePool, root: *Node) Tree {
+        return Tree{ .root_node = root, .pool = self };
     }
 
     pub fn newLeaf(self: *NodePool, hash: *const [32]u8) !*Node {

--- a/packages/persistent-merkle-tree/src/pool.zig
+++ b/packages/persistent-merkle-tree/src/pool.zig
@@ -33,7 +33,8 @@ pub const NodePool = struct {
         const zero_list = try arena_allocator.alloc(*Node, MAX_NODES_DEPTH);
         try zh.initZeroHash(&arena_allocator, MAX_NODES_DEPTH);
         for (0..MAX_NODES_DEPTH) |i| {
-            zero_list[i] = try nm.initZeroNode(arena_allocator, try zh.getZeroHash(i));
+            const prev_zero = if (i == 0) null else zero_list[i - 1];
+            zero_list[i] = try nm.initZeroNode(arena_allocator, try zh.getZeroHash(i), prev_zero, prev_zero);
         }
         return NodePool{
             .leaf_nodes = try LeafList.initCapacity(arena_allocator, capacity),

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -11,6 +11,7 @@ pub const deinitZeroHash = zero_hash.deinitZeroHash;
 pub const sha256Hash = @import("./sha256.zig").sha256Hash;
 pub const HashError = @import("./sha256.zig").HashError;
 pub const NodePool = @import("./pool.zig").NodePool;
+pub const setNodesAtDepth = @import("./tree.zig").setNodesAtDepth;
 
 test {
     testing.refAllDecls(@This());

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -10,7 +10,7 @@ pub const getZeroHash = zero_hash.getZeroHash;
 pub const deinitZeroHash = zero_hash.deinitZeroHash;
 pub const sha256Hash = @import("./sha256.zig").sha256Hash;
 pub const HashError = @import("./sha256.zig").HashError;
-pub const NodePool = @import("./tree.zig").NodePool;
+pub const NodePool = @import("./pool.zig").NodePool;
 
 test {
     testing.refAllDecls(@This());

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -10,6 +10,7 @@ pub const getZeroHash = zero_hash.getZeroHash;
 pub const deinitZeroHash = zero_hash.deinitZeroHash;
 pub const sha256Hash = @import("./sha256.zig").sha256Hash;
 pub const HashError = @import("./sha256.zig").HashError;
+pub const NodePool = @import("./tree.zig").NodePool;
 
 test {
     testing.refAllDecls(@This());

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -11,7 +11,8 @@ pub const deinitZeroHash = zero_hash.deinitZeroHash;
 pub const sha256Hash = @import("./sha256.zig").sha256Hash;
 pub const HashError = @import("./sha256.zig").HashError;
 pub const NodePool = @import("./pool.zig").NodePool;
-pub const setNodesAtDepth = @import("./tree.zig").setNodesAtDepth;
+pub const Tree = @import("./tree.zig").Tree;
+// TODO: publish more apis inside Tree if needed
 
 test {
     testing.refAllDecls(@This());

--- a/packages/persistent-merkle-tree/src/tree.zig
+++ b/packages/persistent-merkle-tree/src/tree.zig
@@ -1,0 +1,262 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const nm = @import("./node.zig");
+const Node = nm.Node;
+const NodePool = @import("./pool.zig").NodePool;
+const MAX_NODES_DEPTH = @import("./const.zig").MAX_NODES_DEPTH;
+
+// TODO: HashComputation
+/// Set multiple nodes in batch, editing and traversing nodes strictly once.
+/// - gindexes MUST be sorted in ascending order beforehand.
+/// - All gindexes must be at the exact same depth.
+/// - Depth must be > 0, if 0 just replace the root node.
+///
+/// Strategy: for each gindex in `gindexes` navigate to the depth of its parent,
+/// and create a new parent. Then calculate the closest common depth with the next
+/// gindex and navigate upwards creating or caching nodes as necessary. Loop and repeat.
+///
+/// Supports index up to `Number.MAX_SAFE_INTEGER`.
+/// cannot make nodes as const because we may modify ref_count
+pub fn setNodesAtDepth(pool: *NodePool, root_node: *const Node, nodes_depth: usize, indexes: []usize, nodes: []*Node) !*Node {
+    if (nodes_depth > MAX_NODES_DEPTH) {
+        return error.InvalidDepth;
+    }
+
+    // depth depthi   gindexes   indexes
+    // 0     1           1          0
+    // 1     0         2   3      0   1
+    // 2     -        4 5 6 7    0 1 2 3
+    // '10' means, at depth 1, node is at the left
+    //
+    // For index N check if the bit at position depthi is set to navigate right at depthi
+    // ```
+    // mask = 1 << depthi
+    // goRight = (N & mask) == mask
+    // ```
+
+    // If depth is 0 there's only one node max and the optimization below will cause a navigation error.
+    // For this case, check if there's a new root node and return it, otherwise the current rootNode.
+    if (nodes_depth == 0) {
+        const node: *Node = @constCast(if (nodes.len > 0) nodes[0] else root_node);
+        return node;
+    }
+
+    // Contiguous filled stack of parent nodes. It get filled in the first descent
+    // Indexed by depthi
+    var parent_nodes_stack = [_]*Node{@constCast(root_node)} ** MAX_NODES_DEPTH;
+
+    // Temp stack of left parent nodes, index by depthi.
+    // Node leftParentNodeStack[depthi] is a node at d = depthi - 1, such that:
+    // ```
+    // parentNodeStack[depthi].left = leftParentNodeStack[depthi]
+    // ```
+    var left_parent_node_stack = [_]?*Node{null} ** MAX_NODES_DEPTH;
+
+    // Ignore first bit "1", then substract 1 to get to the parent
+    const depth_i_root: usize = nodes_depth - 1;
+    const depth_i_parent = 0;
+    var depth_i = depth_i_root;
+    var node: *Node = @constCast(root_node);
+
+    // Insert root node to make the loop below general
+    // parent_nodes_stack[depth_i_root] = node;
+
+    var i: usize = 0;
+    while (i < indexes.len) : (i += 1) {
+        const index: usize = indexes[i];
+
+        // Navigate down until parent depth, and store the chain of nodes
+        //
+        // Starts from latest common depth, so node is the parent node at `depthi`
+        // When persisting the next node, store at the `d - 1` since its the child of node at `depthi`
+        //
+        // Stops at the level above depthiParent. For the re-binding routing below node must be at depthiParent
+        var d: usize = depth_i;
+        while (d > depth_i_parent) : (d -= 1) {
+            node = if (isLeftNode(d, index)) try nm.getLeft(node) else try nm.getRight(node);
+            parent_nodes_stack[d - 1] = node;
+        }
+
+        depth_i = depth_i_parent;
+
+        // If this is the left node, check first it the next node is on the right
+        //
+        //   -    If both nodes exist, create new
+        //  / \
+        // x   x
+        //
+        //   -    If only the left node exists, rebind left
+        //  / \
+        // x   -
+        //
+        //   -    If this is the right node, only the right node exists, rebind right
+        //  / \
+        // -   x
+
+        // d = 0, mask = 1 << d = 1
+        const is_left_leaf_node = (index & 1) != 1;
+        if (is_left_leaf_node) {
+            // Next node is the very next to the right of current node
+            if (index + 1 == indexes[i + 1]) {
+                node = try pool.newBranch(nodes[i], nodes[i + 1]);
+                // Move pointer one extra forward since node has consumed two nodes
+                i += 1;
+            } else {
+                const old_node = node;
+                node = try pool.newBranch(nodes[i], try nm.getRight(old_node));
+            }
+        } else {
+            const old_node = node;
+            node = try pool.newBranch(try nm.getLeft(old_node), nodes[i]);
+        }
+
+        // Here `node` is the new BranchNode at depthi `depthiParent`
+
+        // Now climb upwards until finding the common node with the next index
+        // For the last iteration, climb to the root at `depthiRoot`
+        const is_last_index = i >= indexes.len - 1;
+        const diff_depth_i = if (is_last_index) depth_i_root else try findDiffDepthi(index, indexes[i + 1]);
+
+        // When climbing up from a left node there are two possible paths
+        // 1. Go to the right of the parent: Store left node to rebind latter
+        // 2. Go another level up: Will never visit the left node again, so must rebind now
+
+        // 🡼 \     Rebind left only, will never visit this node again
+        // 🡽 /\
+        //
+        //    / 🡽  Rebind left only (same as above)
+        // 🡽 /\
+        //
+        // 🡽 /\ 🡾  Store left node to rebind the entire node when returning
+        //
+        // 🡼 \     Rebind right with left if exists, will never visit this node again
+        //   /\ 🡼
+        //
+        //    / 🡽  Rebind right with left if exists (same as above)
+        //   /\ 🡼
+
+        d = depth_i_parent + 1;
+        while (d <= diff_depth_i) : (d += 1) {
+            // If node is on the left, store for latter
+            // If node is on the right merge with stored left node
+            if (nodes_depth < d + 1) {
+                return error.InvalidDepth;
+            }
+            if (isLeftNode(d, index)) {
+                if (is_last_index or d != diff_depth_i) {
+                    // If it's last index, bind with parent since it won't navigate to the right anymore
+                    // Also, if still has to move upwards, rebind since the node won't be visited anymore
+                    const old_node = node;
+                    node = try pool.newBranch(old_node, try nm.getRight(parent_nodes_stack[d]));
+                } else {
+                    // Only store the left node if it's at d = diffDepth
+                    left_parent_node_stack[d] = node;
+                    node = parent_nodes_stack[d];
+                }
+            } else {
+                const left_node_or_null = left_parent_node_stack[d];
+
+                if (left_node_or_null) |left_node| {
+                    const old_node = node;
+                    node = try pool.newBranch(left_node, old_node);
+                    left_parent_node_stack[d] = null;
+                } else {
+                    const old_node = node;
+                    node = try pool.newBranch(try nm.getLeft(parent_nodes_stack[d]), old_node);
+                }
+            }
+        }
+
+        // Prepare next loop
+        // Go to the parent of the depth with diff, to switch branches to the right
+        depth_i = diff_depth_i;
+    }
+
+    // Done, return new root node
+    return node;
+}
+
+///
+/// depth depthi   gindexes   indexes
+/// 0     1           1          0
+/// 1     0         2   3      0   1
+/// 2     -        4 5 6 7    0 1 2 3
+/// **Conditions**:
+/// - `from` and `to` must not be equal
+pub fn findDiffDepthi(from: usize, to: usize) !usize {
+    if (from == to) {
+        return error.InvalidArgument;
+    }
+
+    // 0 -> 0, 1 -> 1, 2 -> 2, 3 -> 2, 4 -> 3
+    const from_plus_one: f64 = @floatFromInt(from + 1);
+    const to_plus_one: f64 = @floatFromInt(to + 1);
+    const num_bits_0: usize = @intFromFloat(@ceil(@log2(from_plus_one)));
+    const num_bits_1: usize = @intFromFloat(@ceil(@log2(to_plus_one)));
+
+    // these indexes stay in 2 sides of a merkle tree
+    if (num_bits_0 != num_bits_1) {
+        // must offset by one to match the depthi scale
+        return @max(num_bits_0, num_bits_1) - 1;
+    }
+
+    // same number of bits
+    const xor = from ^ to;
+    const tmp: f64 = @floatFromInt(xor + 1);
+    const num_bits_diff: usize = @intFromFloat(@ceil(@log2(tmp)));
+    return num_bits_diff - 1;
+}
+
+/// Returns true if the `index` at `depth` is a left node, false if it is a right node.
+///
+/// In Eth2 case the biggest tree's index is 2**40 (VALIDATOR_REGISTRY_LIMIT)
+fn isLeftNode(depth_i: usize, index: usize) bool {
+    // depth_i should fit u6, validated in setNodesAtDepth()
+    const shift: u6 = @intCast(depth_i);
+    const mask: usize = @as(usize, 1) << shift;
+    return (index & mask) != mask;
+}
+
+test "findDiffDepthi" {
+    const TestCase = struct {
+        index0: usize,
+        index1: usize,
+        expected: usize,
+    };
+
+    const tcs = [_]TestCase{
+        .{ .index0 = 0, .index1 = 1, .expected = 0 },
+        // 2 sides of a 4-width tree
+        .{ .index0 = 1, .index1 = 3, .expected = 1 },
+        // 2 sides of a 8-width tree
+        .{ .index0 = 3, .index1 = 4, .expected = 2 },
+        // 16 bits
+        .{ .index0 = 0, .index1 = 0xffff, .expected = 15 },
+        // 31 bits, different number of bits
+        .{ .index0 = 5, .index1 = (0xffffffff >> 1) - 5, .expected = 30 },
+        // 31 bits, same number of bits
+        .{ .index0 = 0x7fffffff, .index1 = 0x70000000, .expected = 27 },
+        // 32 bits tree, different number of bits
+        .{ .index0 = 0, .index1 = 0xffffffff, .expected = 31 },
+        .{ .index0 = 0, .index1 = (0xffffffff >> 1) + 1, .expected = 31 },
+        .{ .index0 = 0xffffffff >> 1, .index1 = (0xffffffff >> 1) + 1, .expected = 31 },
+        // 32 bits tree, same number of bits
+        .{ .index0 = 0xf0000000, .index1 = 0xffffffff, .expected = 27 },
+        // below tests are same to first tests but go from right to left
+        // similar to {0, 1}
+        .{ .index0 = 0xffffffff - 1, .index1 = 0xffffffff, .expected = 0 },
+        // similar to {1, 3}
+        .{ .index0 = 0xffffffff - 3, .index1 = 0xffffffff - 1, .expected = 1 },
+        // similar to {3, 4}
+        .{ .index0 = 0xffffffff - 4, .index1 = 0xffffffff - 3, .expected = 2 },
+        // more than 32 bits, same number of bits
+        .{ .index0 = 1153210973487, .index1 = 1344787435182, .expected = 37 },
+        // more than 32 bits, different number of bits
+        .{ .index0 = 1153210973487, .index1 = 1344787435182 >> 2, .expected = 40 },
+    };
+
+    for (tcs) |tc| {
+        const result = try findDiffDepthi(tc.index0, tc.index1);
+        try expect(result == tc.expected);
+    }
+}

--- a/packages/persistent-merkle-tree/src/tree.zig
+++ b/packages/persistent-merkle-tree/src/tree.zig
@@ -784,7 +784,11 @@ test "Tree batch setNodes" {
         .{ .depth = 4, .gindexes = &.{ 16, 20, 30, 31 } },
         .{ .depth = 5, .gindexes = &.{33} },
         .{ .depth = 5, .gindexes = &.{34} },
-        // .{ .depth = 10, .gindexes = &.{ 1024, 1061, 1098, 1135, 1172, 1209, 1246, 1283 } },
+        .{ .depth = 10, .gindexes = &.{ 1024, 1061, 1098, 1135, 1172, 1209, 1246, 1283 } },
+        // .{.depth = 40, .gindexes = &.{std.math.pow(u64, 2, 40) + 1000, std.math.pow(u64, 2, 40) + 1_000_000, std.math.pow(u64, 2, 40) + 1_000_000_000}}
+        // Math.pow(2, 40) = 1099511627776
+        .{ .depth = 40, .gindexes = &.{ 1099511627776 + 1000, 1099511627776 + 1_000_000, 1099511627776 + 1_000_000_000 } },
+        .{ .depth = 40, .gindexes = &.{ 1157505940782, 1349082402477, 1759777921993 } },
     };
 
     const allocator = std.testing.allocator;

--- a/packages/persistent-merkle-tree/src/tree.zig
+++ b/packages/persistent-merkle-tree/src/tree.zig
@@ -142,6 +142,7 @@ pub const Tree = struct {
     // TODO: getSingleProof
     // TODO: getProof
 
+    /// unreferece the root node to possibly return it to the pool
     pub fn unref(self: *Tree) !void {
         try self.pool.unref(self._root_node);
     }

--- a/packages/persistent-merkle-tree/src/tree.zig
+++ b/packages/persistent-merkle-tree/src/tree.zig
@@ -1,0 +1,189 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
+// node module
+const nm = @import("./node.zig");
+const Node = nm.Node;
+const BranchNode = nm.BranchNode;
+const LeafNode = nm.LeafNode;
+
+const LeafList = ArrayList(*Node);
+const BranchList = ArrayList(*Node);
+pub const NodePool = struct {
+    leaf_nodes: LeafList,
+    branch_nodes: BranchList,
+    // no need to call destroyNode() on this
+    place_holder: *Node,
+    arena: *ArenaAllocator,
+    allocator: Allocator,
+    // these variables are useful for metrics and tests
+    branch_node_count: usize,
+    leaf_node_count: usize,
+
+    pub fn init(allocator: Allocator, capacity: usize) !NodePool {
+        const arena = try allocator.create(ArenaAllocator);
+        arena.* = ArenaAllocator.init(allocator);
+        const arena_allocator = arena.allocator();
+        const hash = [_]u8{0} ** 32;
+        const place_holder = try nm.initLeafNode(arena_allocator, &hash);
+        return NodePool{
+            .leaf_nodes = try LeafList.initCapacity(arena_allocator, capacity),
+            .branch_nodes = try BranchList.initCapacity(arena_allocator, capacity),
+            .place_holder = place_holder,
+            .arena = arena,
+            .allocator = allocator,
+            .branch_node_count = 0,
+            .leaf_node_count = 0,
+        };
+    }
+
+    pub fn deinit(self: *NodePool) void {
+        self.leaf_nodes.deinit();
+        self.branch_nodes.deinit();
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+    }
+
+    pub fn createLeaf(self: *NodePool, hash: *const [32]u8) !*Node {
+        const nodeOrNull = self.leaf_nodes.popOrNull();
+        if (nodeOrNull) |node| {
+            // reuse LeafNode from pool
+            switch (node.*) {
+                .Leaf => |leaf| {
+                    @memcpy(leaf.hash.*[0..], hash.*[0..]);
+                    nm.setRefCount(node, 0);
+                    return node;
+                },
+                else => unreachable,
+            }
+        }
+
+        // create new
+        const node = try nm.initLeafNode(self.arena.allocator(), hash);
+        self.leaf_node_count += 1;
+        return node;
+    }
+
+    pub fn createBranch(self: *NodePool, left: *Node, right: *Node) !*Node {
+        const nodeOrNull = self.branch_nodes.popOrNull();
+        if (nodeOrNull) |node| {
+            // reuse BranchNode from pool
+            switch (node.*) {
+                .Branch => {
+                    const branch = &node.Branch;
+                    branch.hash_computed = false;
+                    branch.left = left;
+                    branch.right = right;
+                    nm.incRefCount(left);
+                    nm.incRefCount(right);
+                    nm.setRefCount(node, 0);
+                    return node;
+                },
+                else => unreachable,
+            }
+        }
+
+        // create new
+        const node = try nm.initBranchNode(self.arena.allocator(), left, right);
+        self.branch_node_count += 1;
+        return node;
+    }
+
+    pub fn destroyNode(self: *NodePool, node: *Node) !void {
+        switch (node.*) {
+            .Leaf => {
+                const leaf = &node.Leaf;
+                leaf.decRefCount();
+                if (leaf.ref_count == 0) {
+                    try self.leaf_nodes.append(node);
+                    @memset(leaf.hash.*[0..], 0);
+                }
+            },
+            .Branch => {
+                const branch = &node.Branch;
+                branch.decRefCount();
+                if (branch.ref_count == 0) {
+                    try self.destroyNode(branch.left);
+                    try self.destroyNode(branch.right);
+                    try self.branch_nodes.append(node);
+                    @memset(branch.hash.*[0..], 0);
+                    branch.left = self.place_holder;
+                    branch.right = self.place_holder;
+                    branch.hash_computed = false;
+                }
+            },
+        }
+    }
+};
+
+test "recreate the same tree" {
+    const allocator = std.testing.allocator;
+    var pool = try NodePool.init(allocator, 10);
+    defer pool.deinit();
+
+    const hash1: [32]u8 = [_]u8{1} ** 32;
+    const hash2: [32]u8 = [_]u8{2} ** 32;
+    const hash3: [32]u8 = [_]u8{3} ** 32;
+    const hash4: [32]u8 = [_]u8{4} ** 32;
+
+    // tree 1 is a full tree created from 4 leaves
+    var leaf1 = try pool.createLeaf(&hash1);
+    var leaf2 = try pool.createLeaf(&hash2);
+    var leaf3 = try pool.createLeaf(&hash3);
+    var leaf4 = try pool.createLeaf(&hash4);
+
+    var branch1 = try pool.createBranch(leaf1, leaf2);
+    var branch2 = try pool.createBranch(leaf3, leaf4);
+
+    var rootNode = try pool.createBranch(branch1, branch2);
+    var expected_root = [_]u8{0} ** 32;
+    const root = nm.getRoot(rootNode);
+    @memcpy(expected_root[0..], root.*[0..]);
+
+    // tree 2 is a clone of tree 1 with different root
+    var rootNode2 = try pool.createBranch(branch1, branch2);
+
+    // destroy tree1, only rootNode is released to pool
+    try pool.destroyNode(rootNode);
+    try expect(pool.leaf_nodes.items.len == 0);
+    try expect(pool.branch_nodes.items.len == 1);
+    try expect(pool.leaf_node_count == 4);
+    try expect(pool.branch_node_count == 4);
+
+    // also destroy tree 2, all nodes are released to pool
+    try pool.destroyNode(rootNode2);
+    try expect(pool.leaf_nodes.items.len == 4);
+    try expect(pool.branch_nodes.items.len == 4);
+    try expect(pool.leaf_node_count == 4);
+    try expect(pool.branch_node_count == 4);
+
+    // recreate the same tree
+    leaf1 = try pool.createLeaf(&hash1);
+    leaf2 = try pool.createLeaf(&hash2);
+    leaf3 = try pool.createLeaf(&hash3);
+    leaf4 = try pool.createLeaf(&hash4);
+
+    branch1 = try pool.createBranch(leaf1, leaf2);
+    branch2 = try pool.createBranch(leaf3, leaf4);
+
+    rootNode = try pool.createBranch(branch1, branch2);
+
+    // only rootNode2 is in the pool
+    try expect(pool.leaf_nodes.items.len == 0);
+    try expect(pool.branch_nodes.items.len == 1);
+
+    rootNode2 = try pool.createBranch(branch1, branch2);
+    // should have no more nodes in pool
+    try expect(pool.leaf_nodes.items.len == 0);
+    try expect(pool.branch_nodes.items.len == 0);
+
+    // no new nodes created
+    try expect(pool.leaf_node_count == 4);
+    try expect(pool.branch_node_count == 4);
+
+    // hash should be the same
+    const new_root = nm.getRoot(rootNode);
+    try std.testing.expectEqualSlices(u8, expected_root[0..], new_root.*[0..]);
+}

--- a/packages/persistent-merkle-tree/src/util.zig
+++ b/packages/persistent-merkle-tree/src/util.zig
@@ -29,6 +29,7 @@ pub fn getByteBoolArray(byte: u8) [8]bool {
 /// given a big bit_array and a gindex, populate the bit_array with the bits of gindex using getByteBoolArray
 /// return the total number of bits populated
 /// note that this is big-endian, which is the same to javascript's Number.toString(2)
+/// consumer can use stack allocation for bit_array
 pub fn populateBitArray(bit_array: []bool, gindex: u64) Error!u8 {
     const total_num_bits = numBits(gindex);
     if (bit_array.len < total_num_bits) {
@@ -36,16 +37,23 @@ pub fn populateBitArray(bit_array: []bool, gindex: u64) Error!u8 {
     }
     var buf8: [8]u8 = undefined;
     std.mem.writeInt(u64, &buf8, gindex, .little);
-    outer: for (buf8, 0..) |byte, i| {
+    // bits written starts from the right
+    var num_bits_written: usize = 0;
+    // byte_idx starts from the right most byte due to big endian
+    outer: for (buf8, 0..) |byte, byte_idx| {
         const booleans_in_byte = getByteBoolArray(byte);
         // only the last `num_bits` bits have value
-        const num_bits: usize = @intCast(total_num_bits - i * 8);
-        for (booleans_in_byte[(8 - num_bits)..], 0..) |bit, j| {
-            const bit_idx = i * 8 + j;
-            bit_array[bit_idx] = bit;
-            if (bit_idx >= total_num_bits - 1) {
-                break :outer;
-            }
+        //                         num_bits    num_bits_written
+        // |-------- ... ---------|-----------|----------------|
+        const num_bits: usize = @intCast(@min(total_num_bits - byte_idx * 8, 8));
+        // write to the last num_bits except for num_bits_written
+        for (booleans_in_byte[(8 - num_bits)..], 0..) |bit, bit_idx| {
+            const global_bit_idx = total_num_bits - num_bits_written - num_bits + bit_idx;
+            bit_array[global_bit_idx] = bit;
+        }
+        num_bits_written += num_bits;
+        if (num_bits_written >= total_num_bits) {
+            break :outer;
         }
     }
 
@@ -57,16 +65,32 @@ pub fn numBits(value: u64) u8 {
     return 64 - @clz(value);
 }
 
+// expected result is the same to NodeJS Number.toString(2)
 test "populateBitArray" {
-    var bit_array: [64]bool = [_]bool{false} ** 64;
-    // 5 = 0b101
-    var num_bits = try populateBitArray(bit_array[0..], 5);
-    try expect(num_bits == 3);
-    try std.testing.expectEqualSlices(bool, &[_]bool{ true, false, true }, bit_array[0..num_bits]);
-    // 42 = 0b101010
-    num_bits = try populateBitArray(bit_array[0..], 42);
-    try expect(num_bits == 6);
-    try std.testing.expectEqualSlices(bool, &[_]bool{ true, false, true, false, true, false }, bit_array[0..num_bits]);
+    const TestCase = struct {
+        gindex: u64,
+        num_bits: u8,
+        expected: []const bool,
+    };
+
+    const tcs = [_]TestCase{
+        // 5 = 0b101
+        .{ .gindex = 5, .num_bits = 3, .expected = &.{ true, false, true } },
+        // 42 = 0b101010
+        .{ .gindex = 42, .num_bits = 6, .expected = &.{ true, false, true, false, true, false } },
+        // 1024 = 0b10000000000
+        .{ .gindex = 1024, .num_bits = 11, .expected = &.{ true, false, false, false, false, false, false, false, false, false, false } },
+        // 1025 = 0b10000000001
+        .{ .gindex = 1025, .num_bits = 11, .expected = &.{ true, false, false, false, false, false, false, false, false, false, true } },
+        // 1_000_000 = 0b11110100001001000000
+        .{ .gindex = 1_000_000, .num_bits = 20, .expected = &.{ true, true, true, true, false, true, false, false, false, false, true, false, false, true, false, false, false, false, false, false } },
+    };
+    for (tcs[0..]) |tc| {
+        var bit_array: [64]bool = [_]bool{false} ** 64;
+        const num_bits = try populateBitArray(bit_array[0..], tc.gindex);
+        try expect(num_bits == tc.num_bits);
+        try std.testing.expectEqualSlices(bool, tc.expected, bit_array[0..num_bits]);
+    }
 }
 
 test "numBits" {

--- a/packages/persistent-merkle-tree/src/util.zig
+++ b/packages/persistent-merkle-tree/src/util.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+/// Globally cache this information
+/// 1 => [true false false false false false false false]
+/// 5 => [true false true false false fase false false]
+/// 42 => [true false true false true false false false] = 0b101010
+var byteToBitBooleanArrays: [256]?[8]bool = [_]?[8]bool{null} ** 256;
+
+/// equivalent version of javascript's Number.toString(2)
+/// it returns big-endian format
+pub fn getByteBoolArray(byte: u8) [8]bool {
+    const value = byteToBitBooleanArrays[byte];
+    return if (value == null) {
+        var value2 = [_]bool{false} ** 8;
+        for (0..8) |bit| {
+            const to_shift: u3 = @intCast(bit);
+            value2[7 - bit] = (byte & (@as(u8, 1) << to_shift)) != 0;
+        }
+        byteToBitBooleanArrays[byte] = value2;
+        return value2;
+    } else value.?;
+}
+
+/// given a big bit_array and a gindex, populate the bit_array with the bits of gindex using getByteBoolArray
+/// return the total number of bits populated
+/// note that this is big-endian, which is the same to javascript's Number.toString(2)
+pub fn populateBitArray(bit_array: []bool, gindex: u64) !u8 {
+    const total_num_bits = numBits(gindex);
+    if (bit_array.len < total_num_bits) {
+        return error.TooFewBits;
+    }
+    var buf8: [8]u8 = undefined;
+    std.mem.writeInt(u64, &buf8, gindex, .little);
+    outer: for (buf8, 0..) |byte, i| {
+        const booleans_in_byte = getByteBoolArray(byte);
+        // only the last `num_bits` bits have value
+        const num_bits: usize = @intCast(total_num_bits - i * 8);
+        for (booleans_in_byte[(8 - num_bits)..], 0..) |bit, j| {
+            const bit_idx = i * 8 + j;
+            bit_array[bit_idx] = bit;
+            if (bit_idx >= total_num_bits - 1) {
+                break :outer;
+            }
+        }
+    }
+
+    return total_num_bits;
+}
+
+pub fn numBits(value: u64) u8 {
+    if (value == 0) return 0;
+    return 64 - @clz(value);
+}
+
+test "populateBitArray" {
+    var bit_array: [64]bool = [_]bool{false} ** 64;
+    // 5 = 0b101
+    var num_bits = try populateBitArray(bit_array[0..], 5);
+    try expect(num_bits == 3);
+    try std.testing.expectEqualSlices(bool, &[_]bool{ true, false, true }, bit_array[0..num_bits]);
+    // 42 = 0b101010
+    num_bits = try populateBitArray(bit_array[0..], 42);
+    try expect(num_bits == 6);
+    try std.testing.expectEqualSlices(bool, &[_]bool{ true, false, true, false, true, false }, bit_array[0..num_bits]);
+}
+
+test "numBits" {
+    try expect(numBits(0) == 0);
+    try expect(numBits(1) == 1);
+    // 42 = 0b101010
+    try expect(numBits(42) == 6);
+    // 64 = 0b1000000
+    try expect(numBits(64) == 7);
+}
+
+test "getByteBoolArray" {
+    // // 5 = 0b101
+    var booleans = getByteBoolArray(5);
+    try std.testing.expectEqualSlices(bool, &[_]bool{ false, false, false, false, false, true, false, true }, booleans[0..]);
+    // 42 = 0b101010
+    booleans = getByteBoolArray(42);
+    try std.testing.expectEqualSlices(bool, &[_]bool{ false, false, true, false, true, false, true, false }, booleans[0..]);
+}

--- a/packages/persistent-merkle-tree/src/util.zig
+++ b/packages/persistent-merkle-tree/src/util.zig
@@ -7,6 +7,10 @@ const expect = std.testing.expect;
 /// 42 => [true false true false true false false false] = 0b101010
 var byteToBitBooleanArrays: [256]?[8]bool = [_]?[8]bool{null} ** 256;
 
+pub const Error = error{
+    TooFewBits,
+};
+
 /// equivalent version of javascript's Number.toString(2)
 /// it returns big-endian format
 pub fn getByteBoolArray(byte: u8) [8]bool {
@@ -25,7 +29,7 @@ pub fn getByteBoolArray(byte: u8) [8]bool {
 /// given a big bit_array and a gindex, populate the bit_array with the bits of gindex using getByteBoolArray
 /// return the total number of bits populated
 /// note that this is big-endian, which is the same to javascript's Number.toString(2)
-pub fn populateBitArray(bit_array: []bool, gindex: u64) !u8 {
+pub fn populateBitArray(bit_array: []bool, gindex: u64) Error!u8 {
     const total_num_bits = numBits(gindex);
     if (bit_array.len < total_num_bits) {
         return error.TooFewBits;

--- a/packages/persistent-merkle-tree/src/zero_hash.zig
+++ b/packages/persistent-merkle-tree/src/zero_hash.zig
@@ -47,7 +47,7 @@ pub fn initZeroHash(allocator: *const std.mem.Allocator, max_depth: usize) !void
     }
 }
 
-pub fn getZeroHash(depth: usize) !*[32]u8 {
+pub fn getZeroHash(depth: usize) !*const [32]u8 {
     if (instance == null) {
         return error.noInitZeroHash;
     }
@@ -74,4 +74,14 @@ test "ZeroHash" {
     };
     try std.testing.expectEqualSlices(u8, hash[0..], expected_hash[0..]);
     // std.debug.print("Hash value: {any}\n", .{hash});
+}
+
+test "memory allocation" {
+    var allocator = std.testing.allocator;
+    try initZeroHash(&allocator, 64);
+    defer deinitZeroHash();
+
+    for (0..64) |i| {
+        _ = try getZeroHash(i);
+    }
 }

--- a/packages/persistent-merkle-tree/src/zero_hash.zig
+++ b/packages/persistent-merkle-tree/src/zero_hash.zig
@@ -2,10 +2,10 @@ const std = @import("std");
 const digest64Into = @import("./sha256.zig").digest64Into;
 
 pub const ZeroHash = struct {
-    allocator: *std.mem.Allocator,
+    allocator: *const std.mem.Allocator,
     zero_hashes: []?[32]u8,
 
-    pub fn init(allocator: *std.mem.Allocator, max_depth: usize) !ZeroHash {
+    pub fn init(allocator: *const std.mem.Allocator, max_depth: usize) !ZeroHash {
         var hashes = try allocator.alloc(?[32]u8, max_depth + 1);
         // Use indexing to assign `null` to each element
         for (0..hashes.len) |i| {
@@ -41,7 +41,7 @@ pub const ZeroHash = struct {
 // Thread-local instance of `?ZeroHash`
 threadlocal var instance: ?ZeroHash = null;
 
-pub fn initZeroHash(allocator: *std.mem.Allocator, max_depth: usize) !void {
+pub fn initZeroHash(allocator: *const std.mem.Allocator, max_depth: usize) !void {
     if (instance == null) {
         instance = try ZeroHash.init(allocator, max_depth);
     }


### PR DESCRIPTION
an initial implementation of persistent-merkle-tree in zig following [typescript implementation](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-merkle-tree)

The Merkle tree implementation uses a centralized node pool to manage all nodes efficiently. Nodes are created by the pool and reused to minimize memory allocations. When a node is no longer needed, you should call the `unref()` method, which decreases the node's reference count.

- Reference Counting: Each node tracks its usage with a reference count. When the count reaches zero, the node is returned to the pool.
- Reusability: Returned nodes are stored in the pool's LeafList and BranchList, making them available for reuse. This significantly reduces the need for frequent memory allocation during the application's lifetime.
- Memory Allocation: A single allocator is managed within the pool, simplifying memory management across the API. When trees are no longer in use, nodes should be returned to the pool via the `unref()` method. The pool will then handle cleanup and deallocate memory when required.

This design ensures efficient memory usage and optimal performance, especially in applications where nodes are frequently created and discarded.

see `README.md` for an example usage.

some big `TODOs`:
- subtreeFillsToContent() functions
- proof
- HashComputation