### PR TITLE
test(consensus-types): test all consensus types

### DIFF
--- a/src/consensus_types/root.zig
+++ b/src/consensus_types/root.zig
@@ -10,7 +10,13 @@ pub const deneb = @import("deneb.zig");
 pub const electra = @import("electra.zig");
 
 test {
+    testing.refAllDecls(primitive);
     testing.refAllDecls(phase0);
+    testing.refAllDecls(altair);
+    testing.refAllDecls(bellatrix);
+    testing.refAllDecls(capella);
+    testing.refAllDecls(deneb);
+    testing.refAllDecls(electra);
 }
 
 const src = blk: {


### PR DESCRIPTION
Previously, we only referenced all declarations within `phase0`, which meant that any compilation errors in other types in other hard forks got ignored (which meant their compile-time checks got ignored).

This PR just fixes that by including them.