### PR TITLE
fix: properly handle basic type vector/list in TreeView

### DIFF
--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -96,7 +96,7 @@ pub fn BoolType() type {
                     new_leaf[byte_index] &= ~mask;
                 }
 
-                return try pool.createLeaf(new_leaf, false);
+                return try pool.createLeaf(&new_leaf, false);
             }
         };
 

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -79,12 +79,12 @@ pub fn UintType(comptime bits: comptime_int) type {
                 out.* = std.mem.readInt(Type, hash[offset..][0..fixed_size], .little);
             }
 
-            pub fn fromValuePacked(node: Node.Id, pool: *Node.Pool, index: usize, value: *const Type) !void {
+            pub fn fromValuePacked(node: Node.Id, pool: *Node.Pool, index: usize, value: *const Type) !Node.Id {
                 const hash = node.getRoot(pool);
                 var new_leaf: [32]u8 = hash.*;
                 const offset = index % (32 / bytes);
                 std.mem.writeInt(Type, new_leaf[offset..][0..bytes], value.*, .little);
-                return try pool.createLeaf(new_leaf, false);
+                return try pool.createLeaf(&new_leaf, false);
             }
         };
 


### PR DESCRIPTION
- Fix chunk index calculation for vector/list of basic type when getting and setting element
- Use `toValuePacked` when getting basic type
- Correctly set/get a single bit in `BoolType().tree`