### PR TITLE
fix: fix tree view bugs for basic vector and list

### DIFF
--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -761,6 +761,9 @@ pub const Id = enum(u32) {
         }
 
         const base_gindex = gindices[0];
+        if (@intFromEnum(base_gindex) <= 1) {
+            return nodes[0];
+        }
 
         const path_len = base_gindex.pathLen();
 

--- a/src/ssz/root.zig
+++ b/src/ssz/root.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 pub const types = @import("type/root.zig");
+pub const BYTES_PER_CHUNK = types.BYTES_PER_CHUNK;
 
 pub const TypeKind = types.TypeKind;
 pub const isBasicType = types.isBasicType;

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -82,7 +82,7 @@ pub fn BoolType() type {
                 var new_leaf: [32]u8 = hash.*;
                 const offset = index % 32;
                 new_leaf[offset] = if (value.*) 1 else 0;
-                return try pool.createLeaf(new_leaf, false);
+                return try pool.createLeaf(&new_leaf, false);
             }
         };
 

--- a/src/ssz/type/root.zig
+++ b/src/ssz/type/root.zig
@@ -28,6 +28,8 @@ pub const VariableVectorType = @import("vector.zig").VariableVectorType;
 pub const FixedContainerType = @import("container.zig").FixedContainerType;
 pub const VariableContainerType = @import("container.zig").VariableContainerType;
 
+pub const BYTES_PER_CHUNK: usize = 32;
+
 test {
     _ = @import("bool.zig");
     _ = @import("uint.zig");

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -79,12 +79,12 @@ pub fn UintType(comptime bits: comptime_int) type {
                 out.* = std.mem.readInt(Type, hash[offset..][0..fixed_size], .little);
             }
 
-            pub fn fromValuePacked(node: Node.Id, pool: *Node.Pool, index: usize, value: *const Type) !void {
+            pub fn fromValuePacked(node: Node.Id, pool: *Node.Pool, index: usize, value: *const Type) !Node.Id {
                 const hash = node.getRoot(pool);
                 var new_leaf: [32]u8 = hash.*;
-                const offset = index % (32 / bytes);
+                const offset = (index * bytes) % 32;
                 std.mem.writeInt(Type, new_leaf[offset..][0..bytes], value.*, .little);
-                return try pool.createLeaf(new_leaf, false);
+                return try pool.createLeaf(&new_leaf, false);
             }
         };
 


### PR DESCRIPTION
**Motivation**

- Fix TreeView regressions when mutating basic SSZ vector/list elements where cached nodes leaked or wrong gindex math corrupted updates.
- Provide regression coverage so basic collection updates round-trip through commit/hashTreeRoot.

Description

- Updated Node.setNodes to return the replacement when the gindex targets the root, letting TreeView rely on it instead of special-casing root swaps.
- Centralized the SSZ chunk size (BYTES_PER_CHUNK = 32) in `root.zig` and reused it in TreeView to compute list/vector child gindices correctly.
- Reworked TreeView basic-element paths to use the packed serializers, reuse the shared gindex helper, and avoid leaking temporary nodes when multiple set* calls occur before commit (refcount guard).
- Fixed BoolType/UintType packed setters to hand the new leaf back to callers (and pass the hash by pointer) so TreeView can own the fresh node.
- Added integration tests covering vector and list element round-trips plus renamed the container test for clarity, asserting commit/hashTreeRoot/roundtrip behavior.