### PR TITLE
feat: add single proof API in the tree

### DIFF
--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -6,6 +6,7 @@ const hashOne = @import("hashing").hashOne;
 const getZeroHash = @import("hashing").getZeroHash;
 const max_depth = @import("hashing").max_depth;
 const Depth = @import("hashing").Depth;
+const proof = @import("proof.zig");
 const Gindex = @import("gindex.zig").Gindex;
 
 hash: [32]u8,
@@ -425,6 +426,16 @@ pub const Id = enum(u32) {
         }
 
         return pool.nodes.items(.right)[@intFromEnum(node_id)];
+    }
+
+    pub fn getSingleProof(
+        root_node: Id,
+        allocator: Allocator,
+        pool: *Pool,
+        gindex: Gindex,
+    ) (Error || proof.Error)![][32]u8 {
+        const single_proof = try proof.createSingleProof(allocator, pool, root_node, gindex);
+        return single_proof.witnesses;
     }
 
     pub fn getState(node_id: Id, pool: *Pool) State {


### PR DESCRIPTION
**Motivation**

Expose a `getSingleProof` helper on Node.Id.

**Description**

- Rewired Node.Id.getSingleProof to delegate to proof.createSingleProof, returning only the witness hashes.
- Added a focused unit test in `node_test.zig` that builds a small Merkle tree and asserts the witness chain matches the expected sibling hashes.